### PR TITLE
Update css/jquery.lightbox.css

### DIFF
--- a/css/jquery.lightbox.css
+++ b/css/jquery.lightbox.css
@@ -12,7 +12,7 @@
  * @example Visit http://leandrovieira.com/projects/jquery/lightbox/ for more informations about this jQuery plugin
  */
 #jquery-overlay {
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
 	z-index: 90;


### PR DESCRIPTION
Fixes #jquery-overlay not showing after scrolling if the lightbox stretches the size of the page.